### PR TITLE
Add ShellCheck linting to CI

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: ShellCheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run ShellCheck
+        run: shellcheck install.sh

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ do
 	link_name="$HOME/.$dot"
 	entity=$(readlink "$link_name")
 	[ "$target" = "$entity" ] && continue # already linked
-	[ -L "$link_name" ] && ([ ! -f "$entity" ] || [ ! -d "$entity" ]) && {
+	[ -L "$link_name" ] && { [ ! -f "$entity" ] || [ ! -d "$entity" ]; } && {
 		# broken symlink
 		dialog
 		continue


### PR DESCRIPTION
Add a GitHub Actions workflow that runs ShellCheck on install.sh for
pushes and pull requests, and fix the SC2235 style warning so the lint
passes cleanly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kdAHGS9VUn7RAz8XD63WT